### PR TITLE
Removed redundant logic fork.

### DIFF
--- a/dist/n.js
+++ b/dist/n.js
@@ -35,12 +35,7 @@ export default function n( ...input ){
                     // Allows modified documentFragments to keep their references between destructive redraws;
                     let clone = node.cloneNode( true );
 
-                    if( next ){
-                        el.insertBefore( clone, el.childNodes[ vdom.indexOf( next ) ] );
-                    }
-                    else {
-                        el.appendChild( clone );
-                    }
+                    el.insertBefore( clone, el.childNodes[ vdom.indexOf( next ) ] || null );
                 }
             }
 


### PR DESCRIPTION
When the 2nd argument of `insertBefore` is null, it is analogous to `appendChild`
